### PR TITLE
Allow paused tasks and pause current task by default

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -21,7 +21,9 @@ est add <task name>
 
 The new task name is the concatenation of all non-flag args, no quotes required.
 An estimate can be provided with -e, otherwise the new task will be unestimated.
+
 If an estimate was provided, the new task can be immediately started with -s.
+Multiple tasks can be started concurrently, see 'est help start'.
 
 Estimates can be provided in minutes "30m" or hours "3.5h". Estimates cannot be
 provided in days or weeks, because est's auto time tracking uses customizable
@@ -48,6 +50,10 @@ Examples:
 
   # Add an estimated task and start it as of one hour ago.
   est a -e 4h -s -a 1h "this is a four hour task I started an hour ago"
+
+  # Add and start an estimated task such that multiple tasks are now started.
+  est a -e 1h -sm multiple tasks started if another was already started
+
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		name := strings.TrimSpace(strings.Join(args, " "))

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -89,6 +89,11 @@ Examples:
 			ef.Tasks = append(ef.Tasks, t)
 			if addCmdStartNow {
 				startTime := applyFlagAgo(time.Now())
+				if err := doFlagMultiple(ef, globalWorkTimes, startTime); err != nil {
+					fmt.Printf("fatal: %v\n", err)
+					os.Exit(1)
+					return
+				}
 				if err := ef.Tasks.Start(globalWorkTimes, len(ef.Tasks)-1, startTime); err != nil {
 					fmt.Printf("fatal: %v\n", err)
 					os.Exit(1)
@@ -123,6 +128,7 @@ func looksLikeIDPrefix(s string) bool {
 var addCmdStartNow bool
 
 func init() {
+	addCmd.PersistentFlags().BoolVarP(&flagMultiple, "multiple", "m", false, "allow multiple started tasks")
 	addCmd.PersistentFlags().StringVarP(&flagLog, "log", "l", "", "log time worked after starting this new task")
 	addCmd.PersistentFlags().StringVarP(&flagEstimate, "estimate", "e", "", "estimate new task")
 	addCmd.PersistentFlags().StringVarP(&flagAgo, "ago", "a", "", "when used with start, start duration ago from now")

--- a/cmd/bash_completion.go
+++ b/cmd/bash_completion.go
@@ -17,7 +17,7 @@ if [ ! -z $(which est) ]; then eval "$(est bash --code)"; fi
 // bashCompletionCmd represents the bash-completion command
 var bashCompletionCmd = &cobra.Command{
 	Use:   "bash",
-	Short: "Enable bash completion for est",
+	Short: "Show how to enable bash completion for est",
 	Long:  bashCompletionHelpMsg,
 	Run: func(cmd *cobra.Command, args []string) {
 		if outputBashCompletionCode {

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -31,8 +31,8 @@ func doFlagLog(t *core.Task, now time.Time) {
 		os.Exit(1)
 		return
 	}
-	if !t.IsStarted() {
-		fmt.Print("fatal: cannot log time worked on unstarted task\n")
+	if !t.IsStarted() && !t.IsPaused() {
+		fmt.Print("fatal: cannot log time on a task which isn't started or paused\n")
 		os.Exit(1)
 		return
 	}

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -9,11 +9,36 @@ import (
 	"time"
 
 	"github.com/ryanberckmans/est/core"
+	"github.com/ryanberckmans/est/core/worktimes"
 )
 
 var flagLog string      // duration of logged time e.g. "30m"
 var flagEstimate string // duration estimate e.g. "2.5h"
 var flagAgo string      // duration ago e.g. "0.5d"
+var flagMultiple bool   // user wants multiple tasks started vs. auto pausing any task in progress.
+
+// doFlagMultiple assumes that one task is about to be started and enforces
+// the semantics of pausing a task in progress or determining if a task
+// can legally be started. doFlagMultiple will cause the passed EstFile to
+// become inconsistent if a task isn't started after returning nil error.
+func doFlagMultiple(ef *core.EstFile, wt worktimes.WorkTimes, now time.Time) error {
+	if flagMultiple {
+		// multiple tasks may be started and no started task (if any) will be paused
+		return nil
+	}
+	started := ef.Tasks.IsStarted().IsNotDeleted()
+	if len(started) == 1 {
+		// multiple disallowed and one task started, pause this task
+		i := ef.Tasks.FindByIDPrefix(started[0].ID().String())
+		if i < 0 {
+			panic(fmt.Sprintf("expected to find task with ID %v", started[0].ID()))
+		}
+		return ef.Tasks.Pause(wt, i, now)
+	} else if len(started) > 1 {
+		return errors.New("cannot start task without --multiple because multiple tasks are currently started")
+	}
+	return nil
+}
 
 func doFlagLog(t *core.Task, now time.Time) {
 	if flagLog != "" && flagAgo != "" {

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -24,7 +24,7 @@ $(est-prompt 2> /dev/null)
 // promptCmd represents the prompt command
 var promptCmd = &cobra.Command{
 	Use:   "prompt",
-	Short: "Integrate est into your bash prompt",
+	Short: "Show how to integrate est into your bash prompt",
 	Long:  promptHelpMsg,
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Stdout.WriteString(promptHelpMsg)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -68,6 +68,11 @@ Examples:
 				}
 			}
 			startTime := applyFlagAgo(time.Now())
+			if err := doFlagMultiple(ef, globalWorkTimes, startTime); err != nil {
+				fmt.Printf("fatal: %v\n", err)
+				os.Exit(1)
+				return
+			}
 			if err := ef.Tasks.Start(globalWorkTimes, i, startTime); err != nil {
 				fmt.Printf("fatal: %v\n", err)
 				os.Exit(1)
@@ -88,6 +93,7 @@ Examples:
 }
 
 func init() {
+	startCmd.PersistentFlags().BoolVarP(&flagMultiple, "multiple", "m", false, "allow multiple started tasks")
 	startCmd.PersistentFlags().StringVarP(&flagEstimate, "estimate", "e", "", "estimate this task before starting")
 	startCmd.PersistentFlags().StringVarP(&flagLog, "log", "l", "", "log time worked after starting this task")
 	startCmd.PersistentFlags().StringVarP(&flagAgo, "ago", "a", "", "start duration ago from now")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -28,6 +28,13 @@ estimate command.
 An estimate can be provided with -e, otherwise the task must already be
 estimated to be started.
 
+Multiple tasks can be started concurrently with -m, otherwise any current task
+will be paused when starting a new task. See 'est help done' for an explanation
+of how time is automatically tracked with multiple started tasks.
+
+Tasks cannot be paused directly. Paused tasks can be restarted, marked done,
+deleted, or have time tracked using 'est log'.
+
 Examples:
   # Start the task with ID prefix "3c".
   est s 3c
@@ -40,6 +47,9 @@ Examples:
 
   # Estimate at thirty minutes and start the task with ID prefix "f6c".
   est s -e 30m f6c
+
+  # Start the task with ID prefix "8a" such that multiple tasks are now started.
+  est s -m 8a
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {

--- a/core/chart.go
+++ b/core/chart.go
@@ -119,7 +119,7 @@ func makeAccuracyRatioChart(ars []AccuracyRatio, now time.Time) *chart.Chart {
 		}
 		ys[i] = ars[i].ratio
 		h := ars[i].duration.Hours()
-		baseDiameter := 2.0
+		baseDiameter := 3.0
 		var w float64
 		switch {
 		case h <= 1:

--- a/core/task.go
+++ b/core/task.go
@@ -386,8 +386,8 @@ func (ts tasks) Pause(wt worktimes.WorkTimes, i int, now time.Time) error {
 // Mark the ith task of tasks as done. See note on Start().
 func (ts tasks) Done(wt worktimes.WorkTimes, i int, now time.Time) error {
 	t := ts[i]
-	if !t.IsStarted() {
-		return errors.New("cannot mark done a task which isn't started")
+	if !t.IsStarted() && !t.IsPaused() {
+		return errors.New("cannot mark done a task which isn't started or paused")
 	}
 	if t.IsDeleted() {
 		// We don't allow starting deleted tasks or deleting a started task, and so never expect a started task to be deleted.

--- a/core/task.go
+++ b/core/task.go
@@ -135,7 +135,7 @@ func (t *Task) Estimated() time.Duration {
 // SetEstimated sets this task's estimated duration.
 func (t *Task) SetEstimated(d time.Duration) error {
 	if !t.IsNeverStarted() {
-		return errors.New("cannot re-estimate a task which has been started; the idea is to get better at up-front estimation")
+		return errors.New("cannot re-estimate a task which has been started")
 	}
 	t.task.Estimated = d
 	t.task.EstimatedAt = time.Now()

--- a/core/task_test.go
+++ b/core/task_test.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ryanberckmans/est/core/worktimes"
+)
+
+func getStartedTask() *Task {
+	t := NewTask()
+	t.task.ActualUpdatedAt = time.Now()
+	t.task.Estimated = time.Minute * 7
+	if !t.IsStarted() {
+		panic("expected started task")
+	}
+	return t
+}
+
+func getPausedTask() *Task {
+	t := getStartedTask()
+	t.task.IsPaused = true
+	if !t.IsPaused() {
+		panic("expected paused task")
+	}
+	return t
+}
+
+func TestPause(t *testing.T) {
+	t.Run("pause a started task", func(t *testing.T) {
+		ts := tasks{getStartedTask()}
+		assert.True(t, ts[0].IsStarted(), "sanity")
+		now := time.Now().Add(time.Minute)
+		wt := worktimes.GetAnonymousWorkTimes()
+		assert.NoError(t, ts.Pause(wt, 0, now), "can pause started task")
+		assert.Equal(t, ts[0].task.PausedAt, now)
+		assert.Equal(t, ts[0].task.ActualUpdatedAt, now)
+		assert.True(t, ts[0].IsPaused())
+		assert.False(t, ts[0].IsStarted(), "sanity")
+	})
+	t.Run("disallowed on paused task", func(t *testing.T) {
+		ts := tasks{getPausedTask()}
+		assert.True(t, ts[0].IsPaused(), "sanity")
+		assert.Error(t, ts[0].SetEstimated(time.Minute), "cannot re-estimate paused task")
+		now := time.Now().Add(time.Minute)
+		wt := worktimes.GetAnonymousWorkTimes()
+		assert.Error(t, ts.Pause(wt, 0, now), "cannot pause paused task")
+		assert.True(t, ts[0].IsPaused(), "still paused")
+	})
+	t.Run("start a paused task", func(t *testing.T) {
+		ts := tasks{getPausedTask()}
+		assert.True(t, ts[0].IsPaused(), "sanity")
+		now := time.Now().Add(time.Minute)
+		wt := worktimes.GetAnonymousWorkTimes()
+		assert.NoError(t, ts.Start(wt, 0, now), "can start paused task")
+		assert.Equal(t, ts[0].task.StartedAt, now)
+		assert.Equal(t, ts[0].task.ActualUpdatedAt, now)
+		assert.True(t, ts[0].IsStarted())
+		assert.False(t, ts[0].IsPaused(), "sanity")
+	})
+	t.Run("mark done a paused task", func(t *testing.T) {
+		ts := tasks{getPausedTask()}
+		assert.True(t, ts[0].IsPaused(), "sanity")
+		oldActualUpdatedAt := ts[0].task.ActualUpdatedAt
+		now := time.Now().Add(time.Minute)
+		wt := worktimes.GetAnonymousWorkTimes()
+		assert.NoError(t, ts.Done(wt, 0, now), "can mark done paused task")
+		assert.Equal(t, ts[0].task.DoneAt, now)
+		assert.Equal(t, ts[0].task.ActualUpdatedAt, oldActualUpdatedAt, "actual updated at not updated because this task was paused and had no time tracked")
+		assert.True(t, ts[0].IsDone())
+		assert.False(t, ts[0].IsPaused(), "sanity")
+	})
+	t.Run("delete a paused task", func(t *testing.T) {
+		ts := tasks{getPausedTask()}
+		assert.True(t, ts[0].IsPaused(), "sanity")
+		assert.NoError(t, ts[0].Delete(), "can delete paused task")
+		assert.True(t, ts[0].IsDeleted())
+		// ts[0].IsPaused is still true because IsDeleted is orthogonal state
+	})
+}

--- a/core/worktimes/worktimes.go
+++ b/core/worktimes/worktimes.go
@@ -205,3 +205,25 @@ func startOfDay(t time.Time) time.Time {
 func endOfDay(t time.Time) time.Time {
 	return startOfDay(t.AddDate(0, 0, 1)).Add(-time.Nanosecond)
 }
+
+// GetAnonymousWorkTimes is a convenience function for downstream testing.
+func GetAnonymousWorkTimes() WorkTimes {
+	wt, err := New(map[time.Weekday]bool{
+		time.Monday:    true,
+		time.Tuesday:   true,
+		time.Wednesday: true,
+		time.Thursday:  true,
+		time.Friday:    true,
+	}, []string{
+		// Work 9:30am-noon
+		"9:30am",
+		"12:00pm",
+		// 30 minutes for lunch, then work 12:30pm-5:30pm
+		"12:30pm",
+		"5:30pm",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return wt
+}


### PR DESCRIPTION
Cmds start and add now take --multiple to allow multiple started tasks.

The default behavior is now to pause a started task when starting another. 
Paused tasks show up as an explicit 'paused' status in 'est ls'.

Task now has an IsPaused field, which is a backwards-compatible data model change.
